### PR TITLE
Get serial getline sample building with litex-vexriscv 

### DIFF
--- a/drivers/serial/uart_liteuart.c
+++ b/drivers/serial/uart_liteuart.c
@@ -43,6 +43,10 @@ struct uart_liteuart_data {
 #endif
 };
 
+#define DEV_DATA(dev)						\
+	((struct uart_liteuart_data * const)(dev)->driver_data)
+
+
 /**
  * @brief Output a character in polled mode.
  *


### PR DESCRIPTION
previous build warnings/errors were:
```
<redacted>/builds/zephyr/drivers/serial/uart_liteuart.c: In function 'liteuart_uart_irq_handler':
<redacted>/builds/zephyr/drivers/serial/uart_liteuart.c:276:36: warning: implicit declaration of function 'DEV_DATA'; did you mean 'ENODATA'? [-Wimplicit-function-declaration]
  struct uart_liteuart_data *data = DEV_DATA(dev);
                                    ^~~~~~~~
                                    ENODATA
<redacted>/builds/zephyr/drivers/serial/uart_liteuart.c:276:36: warning: initialization of 'struct uart_liteuart_data *' from 'int' makes pointer from integer without a cast [-Wint-conversion]

```
and a link error:

```
<redacted>/builds/litex_env/build/zephyr_sdk/riscv32-zephyr-elf/bin/../lib/gcc/riscv32-zephyr-elf/8.3.0/../../../../riscv32-zephyr-elf/bin/ld: drivers/serial/libdrivers__serial.a(uart_liteuart.c.obj): in function `liteuart_uart_irq_handler':
<redacted>/builds/zephyr/drivers/serial/uart_liteuart.c:276: undefined reference to `DEV_DATA'
collect2: error: ld returned 1 exit status

```
after the change was applied:

```
[100%] Linking C executable zephyr.elf
Generating files from zephyr.elf for board: litex_vexriscv
[100%] Built target zephyr_final

```
Though to be fair, I have not got to actually running it yet...
I just started with zephyr today.

thanks,

mtm

